### PR TITLE
Use Craft built-ins for form actions and handle OpenSSL errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 [![Join the chat at https://gitter.im/flipboxfactory/keychain](https://badges.gitter.im/flipboxfactory/keychain.svg)](https://gitter.im/flipboxfactory/keychain?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Latest Version](https://img.shields.io/github/release/flipboxfactory/keychain.svg?style=flat-square)](https://github.com/flipboxfactory/keychain/releases)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/travis/flipboxfactory/keychain/master.svg?style=flat-square)](https://travis-ci.com/flipboxfactory/keychain)
-[![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/flipboxfactory/keychain.svg?style=flat-square)](https://scrutinizer-ci.com/g/flipboxfactory/keychain/code-structure)
-[![Quality Score](https://img.shields.io/scrutinizer/g/flipboxfactory/keychain.svg?style=flat-square)](https://scrutinizer-ci.com/g/flipboxfactory/keychain)
 [![Total Downloads](https://img.shields.io/packagist/dt/flipboxfactory/keychain.svg?style=flat-square)](https://packagist.org/packages/flipboxfactory/keychain)
 
 ## Installation
@@ -26,7 +22,7 @@ $ ./vendor/bin/phpunit
 
 ## Contributing
 
-Please see [CONTRIBUTING](https://github.com/flipboxfactory/keychain/blob/master/CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 
 ## Credits
@@ -35,4 +31,4 @@ Please see [CONTRIBUTING](https://github.com/flipboxfactory/keychain/blob/master
 
 ## License
 
-The MIT License (MIT). Please see [License File](https://github.com/flipboxfactory/keychain/blob/master/LICENSE) for more information.
+Please see [License File](LICENSE.md) for more information.

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "Key pair management for Craft CMS",
   "version": "4.0.0",
   "type": "craft-plugin",
+  "license": "proprietary",
   "keywords": [
     "cms",
     "craftcms",
@@ -15,8 +16,8 @@
     "lib-openssl": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.0",
-    "squizlabs/php_codesniffer": "^2.0"
+    "phpunit/phpunit": "^9.0",
+    "squizlabs/php_codesniffer": "^3.4"
   },
   "autoload": {
     "psr-4": {
@@ -45,5 +46,11 @@
     "developerUrl": "https://www.flipboxdigital.com",
     "changelogUrl": "https://raw.githubusercontent.com/flipboxfactory/keychain/master/CHANGELOG.md",
     "downloadUrl": "https://github.com/flipboxfactory/keychain/archive/master.zip"
+  },
+  "config": {
+    "allow-plugins": {
+      "yiisoft/yii2-composer": true,
+      "craftcms/plugin-installer": true
+    }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
 >
     <logging>
         <log type="tap"
@@ -17,8 +16,6 @@
              target="./build/report.junit.xml"/>
         <log type="coverage-html"
              target="./build/coverage/html"
-             charset="UTF-8"
-             highlight="false"
              lowUpperBound="35"
              highLowerBound="70"/>
         <log type="coverage-text"

--- a/src/KeyChain.php
+++ b/src/KeyChain.php
@@ -100,6 +100,7 @@ class KeyChain extends Plugin
                 'keychain/new'             => 'keychain/cp/view/edit/index',
                 'keychain/<keypairId:\d+>' => 'keychain/cp/view/edit/index',
                 'keychain/openssl'         => 'keychain/cp/view/edit/openssl',
+                'keychain/download-certificate' => 'keychain/cp/view/edit/download-certificate',
             ]
         );
     }

--- a/src/controllers/AbstractUpsertController.php
+++ b/src/controllers/AbstractUpsertController.php
@@ -66,23 +66,20 @@ abstract class AbstractUpsertController extends AbstractController
             $keypair->enabled = true;
         }
 
-
-        if (KeyChain::getInstance()->getService()->save($keypair)) {
-            Craft::$app->getSession()->setNotice(Craft::t('keychain', 'Key pair saved.'));
-        } else {
-            Craft::$app->getSession()->setError(Craft::t('keychain', 'Key pair didn\'t save.'));
+        if (!KeyChain::getInstance()->getService()->save($keypair)) {
+            $this->setFailFlash(Craft::t('keychain', 'Key pair didn\'t save.'));
             return $this->renderTemplate(
                 EditController::TEMPLATE_INDEX,
-                array_merge(
+                EditController::getEditVariables(array_merge(
                     $this->getBaseVariables(),
                     [
                         'keypair' => $keypair,
                     ]
-                )
+                ))
             );
         }
 
-        return $this->redirectToPostedUrl();
+        return $this->asSuccess(Craft::t('keychain', 'Key pair saved.'));
     }
 
     /**
@@ -97,40 +94,34 @@ abstract class AbstractUpsertController extends AbstractController
         /** @var Request $request */
         $request = Craft::$app->request;
 
-        $keychainRecord = (new OpenSSL([
-            'description'            => $request->getBodyParam('description'),
-            'countryName'            => $request->getBodyParam('countryName'),
-            'stateOrProvinceName'    => $request->getBodyParam('stateOrProvinceName'),
-            'localityName'           => $request->getBodyParam('localityName'),
-            'organizationName'       => $request->getBodyParam('organizationName'),
-            'organizationalUnitName' => $request->getBodyParam('organizationalUnitName'),
-            'commonName'             => $request->getBodyParam('commonName'),
-            'emailAddress'           => $request->getBodyParam('emailAddress'),
-        ]))->create();
+        try {
+            $keychainRecord = (new OpenSSL([
+                'daysExpiry'             => (int)$request->getBodyParam('daysExpiry', 365),
+                'description'            => $request->getBodyParam('description'),
+                'countryName'            => $request->getBodyParam('countryName'),
+                'stateOrProvinceName'    => $request->getBodyParam('stateOrProvinceName'),
+                'localityName'           => $request->getBodyParam('localityName'),
+                'organizationName'       => $request->getBodyParam('organizationName'),
+                'organizationalUnitName' => $request->getBodyParam('organizationalUnitName'),
+                'commonName'             => $request->getBodyParam('commonName'),
+                'emailAddress'           => $request->getBodyParam('emailAddress'),
+            ]))->create();
 
-        Craft::configure($keychainRecord, [
-            'enabled'      => $request->getBodyParam('enabled') ?: false,
-            'isEncrypted'  => $request->getBodyParam('isEncrypted') ?: false,
-            'pluginHandle' => $request->getBodyParam('plugin'),
-        ]);
-        $keychainRecord->isDecrypted = true;
-
-        if (KeyChain::getInstance()->getService()->save($keychainRecord)) {
-            Craft::$app->getSession()->setNotice(Craft::t('keychain', 'Key pair saved.'));
-        } else {
-            Craft::$app->getSession()->setError(Craft::t('keychain', 'Key pair didn\'t save.'));
-            return $this->renderTemplate(
-                EditController::TEMPLATE_INDEX,
-                array_merge(
-                    $this->getBaseVariables(),
-                    [
-                        'keypair' => $keychainRecord,
-                    ]
-                )
-            );
+            Craft::configure($keychainRecord, [
+                'enabled'      => $request->getBodyParam('enabled') ?: false,
+                'isEncrypted'  => $request->getBodyParam('isEncrypted') ?: false,
+                'pluginHandle' => $request->getBodyParam('plugin'),
+            ]);
+            $keychainRecord->isDecrypted = true;
+        } catch (\Throwable $e) {
+            return $this->asFailure($e->getMessage());
         }
 
-        return $this->redirectToPostedUrl();
+        if (!KeyChain::getInstance()->getService()->save($keychainRecord)) {
+            return $this->asFailure(Craft::t('keychain', 'Key pair didn\'t save.'));
+        }
+
+        return $this->asSuccess(Craft::t('keychain', 'Key pair saved.'));
     }
 
     /**
@@ -152,26 +143,11 @@ abstract class AbstractUpsertController extends AbstractController
         /** @var KeyChainRecord $keyPair */
         $keyPair = KeyChain::getInstance()->getService()->generateOpenssl($config);
 
-        if (Craft::$app->request->isAjax) {
-            return $this->asJson($keyPair->toArray());
-        }
-
         if (! $keyPair->hasErrors()) {
-            Craft::$app->getSession()->setNotice(Craft::t('keychain', 'Key pair saved.'));
-        } else {
-            Craft::$app->getSession()->setError(Craft::t('keychain', 'Key pair didn\'t save.'));
-            return $this->renderTemplate(
-                EditController::TEMPLATE_INDEX,
-                array_merge(
-                    $this->getBaseVariables(),
-                    [
-                        'keypair' => $keyPair,
-                    ]
-                )
-            );
+            return $this->asSuccess(Craft::t('keychain', 'Key pair created!'), $keyPair->toArray());
         }
 
-        return $this->redirectToPostedUrl();
+        return $this->asFailure(Craft::t('keychain', 'Key pair didn\'t save.'));
     }
 
 
@@ -191,22 +167,11 @@ abstract class AbstractUpsertController extends AbstractController
 
         $keychainRecord->enabled = ! $keychainRecord->enabled;
 
-        if (KeyChain::getInstance()->getService()->save($keychainRecord)) {
-            Craft::$app->getSession()->setNotice(Craft::t('keychain', 'Key pair saved.'));
-        } else {
-            Craft::$app->getSession()->setError(Craft::t('keychain', 'Key pair didn\'t save.'));
-            return $this->renderTemplate(
-                EditController::TEMPLATE_INDEX . '/openssl',
-                array_merge(
-                    $this->getBaseVariables(),
-                    [
-                        'keypair' => $keychainRecord,
-                    ]
-                )
-            );
+        if (!KeyChain::getInstance()->getService()->save($keychainRecord)) {
+            return $this->asFailure(Craft::t('keychain', 'Key pair didn\'t save.'));
         }
 
-        return $this->redirectToPostedUrl();
+        return $this->asSuccess(Craft::t('keychain', 'Key pair saved.'));
     }
 
     /**
@@ -225,21 +190,10 @@ abstract class AbstractUpsertController extends AbstractController
             'id' => $keypairId,
         ])->one();
 
-        if (false !== KeyChain::getInstance()->getService()->delete($keychainRecord)) {
-            Craft::$app->getSession()->setNotice(Craft::t('keychain', 'Key pair deleted.'));
-        } else {
-            Craft::$app->getSession()->setError(Craft::t('keychain', 'Key pair didn\'t delete.'));
-            return $this->renderTemplate(
-                EditController::TEMPLATE_INDEX,
-                array_merge(
-                    $this->getBaseVariables(),
-                    [
-                        'keypair' => $keychainRecord,
-                    ]
-                )
-            );
+        if (!KeyChain::getInstance()->getService()->delete($keychainRecord)) {
+            return $this->asFailure(Craft::t('keychain', 'Key pair didn\'t delete.'));
         }
 
-        return $this->redirectToPostedUrl();
+        return $this->asSuccess(Craft::t('keychain', 'Key pair deleted.'));
     }
 }

--- a/src/controllers/UpsertController.php
+++ b/src/controllers/UpsertController.php
@@ -8,18 +8,6 @@
 
 namespace flipbox\keychain\controllers;
 
-use Craft;
-use craft\base\Plugin;
-use craft\web\Controller;
-use flipbox\keychain\controllers\cp\AbstractController;
-use flipbox\keychain\controllers\cp\view\EditController;
-use flipbox\keychain\KeyChain;
-use flipbox\keychain\records\KeyChainRecord;
-
 class UpsertController extends AbstractUpsertController
 {
-    protected function getPlugin()
-    {
-        return KeyChain::getInstance();
-    }
 }

--- a/src/controllers/cp/AbstractController.php
+++ b/src/controllers/cp/AbstractController.php
@@ -8,6 +8,7 @@
 
 namespace flipbox\keychain\controllers\cp;
 
+use Craft;
 use craft\helpers\UrlHelper;
 use craft\web\Controller;
 use craft\base\Plugin;
@@ -18,7 +19,16 @@ abstract class AbstractController extends Controller
     /**
      * @return Plugin
      */
-    abstract protected function getPlugin();
+    protected function getPlugin()
+    {
+        $handle = Craft::$app->request->getBodyParam('pluginHandle');
+        if ($handle && $plugin = Craft::$app->getModule($handle)) {
+            if ($plugin instanceof Plugin) {
+                return $plugin;
+            }
+        }
+        return KeyChain::getInstance();
+    }
 
     /**
      * @return array

--- a/src/controllers/cp/view/AbstractEditController.php
+++ b/src/controllers/cp/view/AbstractEditController.php
@@ -24,6 +24,56 @@ abstract class AbstractEditController extends AbstractController
     const TEMPLATE_INDEX = 'keychain/_cp/edit';
 
     /**
+     * @param array $variables
+     * @return array
+     */
+    public static function getEditVariables(array $variables)
+    {
+        /** @var ?KeyChainRecord $keypair */
+        $keypair = $variables['keypair'] ?: null;
+        if (!$keypair) {
+            return $variables;
+        }
+
+        if ($keypair->id) {
+            $variables['title'] .= ': Edit';
+            $variables['continueEditingUrl'] = $variables['baseCpPath'] . '/' . $keypair->id;
+
+            $variables['formActions'] = [
+                [
+                    'label' => 'Save and continue editing',
+                    'redirect' => \Craft::$app->getSecurity()->hashData($variables['continueEditingUrl'], null),
+                    'shortcut' => true,
+                ],
+                [
+                    'action' => 'keychain/upsert/change-status',
+                    'label'  => $keypair->enabled ? 'Disable' : 'Enable',
+                ],
+                [
+                    'action' => 'keychain/upsert/delete',
+                    'label'  => 'Delete',
+                    'destructive' => true,
+                ],
+            ];
+
+            $crumb = [
+                'url'   => UrlHelper::cpUrl($variables['continueEditingUrl']),
+                'label' => $variables['keypair']->description ?: '(Untitled)',
+            ];
+        } else {
+            $variables['title'] .= ': Create Bring Your Own Key';
+            $crumb = [
+                'url'   => UrlHelper::cpUrl($variables['baseCpPath'] . '/new'),
+                'label' => 'New',
+            ];
+        }
+
+        $variables['crumbs'][] = $crumb;
+
+        return $variables;
+    }
+
+    /**
      * @param string|null $keypairId
      * @return \yii\web\Response
      */
@@ -32,46 +82,14 @@ abstract class AbstractEditController extends AbstractController
         $variables = $this->getBaseVariables();
 
         if ($keypairId) {
-            $keypair = $variables['keypair'] = KeyChainRecord::find()->where([
+            $variables['keypair'] = KeyChainRecord::find()->where([
                 'id' => $keypairId,
             ])->one();
-            $variables['title'] .= ': Edit';
-
-
-            $variables['actions'] = [
-                [
-                    //action list 1
-                    [
-                        'action' => 'keychain/upsert/change-status',
-                        'label'  => $keypair->enabled ? 'Disable' : 'Enable',
-                    ],
-                    [
-                        'action' => 'keychain/upsert/delete',
-                        'label'  => 'Delete',
-                    ],
-                ],
-            ];
-
-            $crumb = [
-                'url'   => UrlHelper::cpUrl(
-                    $variables['baseCpPath'] . '/' . $keypairId
-                ),
-                'label' => $variables['keypair']->description,
-            ];
         } else {
             $variables['keypair'] = new KeyChainRecord();
-            $variables['title'] .= ': Create Bring Your Own Key';
-            $crumb = [
-                'url'   => UrlHelper::cpUrl(
-                    $variables['baseCpPath'] . '/new'
-                ),
-                'label' => 'New',
-            ];
         }
 
-        $variables['crumbs'][] = $crumb;
-
-
+        $variables = self::getEditVariables($variables);
         $variables = $this->beforeRender($variables);
         return $this->renderTemplate(
             static::TEMPLATE_INDEX,

--- a/src/controllers/cp/view/AbstractEditController.php
+++ b/src/controllers/cp/view/AbstractEditController.php
@@ -9,13 +9,11 @@
 namespace flipbox\keychain\controllers\cp\view;
 
 use Craft;
-use craft\base\Plugin;
 use craft\helpers\UrlHelper;
-use craft\web\Controller;
 use flipbox\keychain\controllers\cp\AbstractController;
-use flipbox\keychain\KeyChain;
 use flipbox\keychain\keypair\traits\OpenSSL;
 use flipbox\keychain\records\KeyChainRecord;
+use yii\web\NotFoundHttpException;
 
 abstract class AbstractEditController extends AbstractController
 {
@@ -122,5 +120,27 @@ abstract class AbstractEditController extends AbstractController
             static::TEMPLATE_INDEX . '/openssl',
             $variables
         );
+    }
+
+    /**
+     * @param $keyId
+     * @return \craft\web\Response|\yii\console\Response
+     * @throws NotFoundHttpException
+     * @throws \yii\web\ForbiddenHttpException
+     * @throws \yii\web\HttpException
+     * @throws \yii\web\RangeNotSatisfiableHttpException
+     */
+    public function actionDownloadCertificate($keyId)
+    {
+        $this->requireAdmin(false);
+
+        /** @var KeyChainRecord $keychain */
+        if (! $keychain = KeyChainRecord::find()->where([
+            'id' => $keyId,
+        ])->one()) {
+            throw new NotFoundHttpException('Key not found');
+        }
+
+        return Craft::$app->response->sendContentAsFile($keychain->getDecryptedCertificate(), 'certificate.crt');
     }
 }

--- a/src/keypair/OpenSSL.php
+++ b/src/keypair/OpenSSL.php
@@ -43,23 +43,45 @@ class OpenSSL extends Model implements KeyPairInterface
 
     public function create(): KeyChainRecord
     {
-
         // Generate a new private (and public) key pair
         $privkey = openssl_pkey_new([
             "private_key_bits" => $this->keyBits,
             "private_key_type" => OPENSSL_KEYTYPE_RSA,
         ]);
 
+        if (!$privkey) {
+            throw new \RuntimeException('Unable to generate a new key pair.');
+        }
+
+        $dn = array_filter($this->toArray($this->attributes()));
+
         // Generate a certificate signing request
-        $csr = openssl_csr_new($this->toArray($this->attributes()), $privkey, ['digest_alg' => $this->digestAlgorithm]);
+        $csr = openssl_csr_new($dn, $privkey, ['digest_alg' => $this->digestAlgorithm]);
+
+        if (!$csr) {
+            throw new \RuntimeException('Unable to generate a certificate signing request.');
+        }
 
         // Generate a self-signed cert, valid for 365 days
         $x509 = openssl_csr_sign($csr, null, $privkey, $this->daysExpiry, ['digest_alg' => $this->digestAlgorithm]);
 
+        if (!$x509) {
+            throw new \RuntimeException('Unable to generate a self-signed cert.');
+        }
+
         // Save your private key, CSR and self-signed cert for later use
-        openssl_csr_export($csr, $csrout);
-        openssl_x509_export($x509, $certout);
-        openssl_pkey_export($privkey, $pkeyout);
+
+        if (!openssl_csr_export($csr, $csrout)) {
+            throw new \RuntimeException('Unable to export CSR.');
+        }
+
+        if (!openssl_x509_export($x509, $certout)) {
+            throw new \RuntimeException('Unable to export cert.');
+        }
+
+        if (!openssl_pkey_export($privkey, $pkeyout)) {
+            throw new \RuntimeException('Unable to export private key');
+        }
 
         return new KeyChainRecord([
             'certificate' => $certout,

--- a/src/records/EmberTrait.php
+++ b/src/records/EmberTrait.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace flipbox\keychain\records;
-
 
 use yii\base\Model;
 

--- a/src/records/KeyChainRecord.php
+++ b/src/records/KeyChainRecord.php
@@ -46,6 +46,8 @@ class KeyChainRecord extends \craft\db\ActiveRecord
     {
         return array_merge(
             [
+                [['key', 'certificate'], 'required'],
+                ['certificate', 'isCertificateX509'],
                 ['key', 'isKeyCertAPair']
             ],
             parent::rules()
@@ -57,9 +59,28 @@ class KeyChainRecord extends \craft\db\ActiveRecord
      * @param $params
      * @param $validator
      */
+    public function isCertificateX509($attribute, $params, $validator)
+    {
+        $cert = $this->getDecryptedCertificateObject();
+        if (!$cert) {
+            $this->addError($attribute, 'Certificate is not a x509 certificate');
+        }
+    }
+
+    /**
+     * @param $attribute
+     * @param $params
+     * @param $validator
+     */
     public function isKeyCertAPair($attribute, $params, $validator)
     {
-        if (! openssl_x509_check_private_key($this->getDecryptedCertificate(), $this->getDecryptedKey())) {
+        $key = openssl_pkey_get_private($this->getDecryptedKey());
+        if (!$key) {
+            $this->addError($attribute, 'Key is not a private key');
+            return;
+        }
+
+        if (! openssl_x509_check_private_key($this->getDecryptedCertificateObject(), $key)) {
             $this->addError($attribute, 'Key and certificate are not a pair.');
         }
     }
@@ -101,5 +122,37 @@ class KeyChainRecord extends \craft\db\ActiveRecord
         }
 
         return $this->decryptedCertificate;
+    }
+
+    /**
+     * @return ?\OpenSSLCertificate
+     */
+    protected function getDecryptedCertificateObject()
+    {
+        $certificateString = $this->getDecryptedCertificate();
+        if (!$certificateString) {
+            return null;
+        }
+
+        $cert = openssl_x509_read($certificateString);
+        if (!$cert) {
+            return null;
+        }
+
+        return $cert;
+    }
+
+    /**
+     * If the certificate is parsable, returns the \DateTimeImmutable that it expires, null otherwise.
+     * @return ?\DateTimeImmutable
+     */
+    public function getCertificateExpiration()
+    {
+        $certText = $this->getDecryptedCertificate();
+        $x509Data = openssl_x509_parse($certText);
+        if (!$x509Data) {
+            return null;
+        }
+        return new \DateTimeImmutable(sprintf('@%d', $x509Data['validTo_time_t']));
     }
 }

--- a/src/services/KeyChainService.php
+++ b/src/services/KeyChainService.php
@@ -36,11 +36,7 @@ class KeyChainService extends Component
      */
     public function save(KeyChainRecord $keyChainRecord, $runValidation = true, $attributeNames = null)
     {
-        if (! $runValidation && $keyChainRecord->validate()) {
-            return false;
-        }
-
-        return $keyChainRecord->save();
+        return $keyChainRecord->save($runValidation, $attributeNames);
     }
 
     /**

--- a/src/templates/_cp/edit/index.twig
+++ b/src/templates/_cp/edit/index.twig
@@ -13,52 +13,33 @@
                         <span class="status {% if keypair.enabled %}active{% else %}inactive{% endif %}"></span>
                         {% if keypair.enabled %}Enabled{% else %}Disabled{% endif %}
                     </div>
-                    {% if actions|length %}
-                        <div>
-                            <div id="action-menubtn" class="btn menubtn" data-icon="settings" title="{{ 'Actions'|t('app') }}"></div>
-                            <div class="menu">
-                                {% for actionList in actions %}
-                                    {% if not loop.first %}<hr>{% endif %}
-                                    <ul>
-                                        {% for actionItem in actionList %}
-                                            <li><a
-                                                        {%- if actionItem.id is defined %} id="{{ actionItem.id }}"{% endif %}
-                                                        {%- if actionItem.action is defined %} class="formsubmit" data-action="{{ actionItem.action }}"{% endif -%}
-                                                >{{ actionItem.label }}</a>
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endfor %}
-                            </div>
-                            <div id="action-spinner" class="spinner hidden"></div>
-                        </div>
-                    {% endif %}
                 </div>
             </div>
-            <hr>
-            <p>
-                {{ "Toggle 'Is Encrypted' to encrypt the key and certificate when it's stored in the db. This uses the Craft security key."|t('keychain') }}
-            </p>
             {{ forms.lightswitchField({
                 label: "Encrypt at Rest"|t('keychain'),
                 id: 'isEncrypted',
                 name: 'isEncrypted',
+                instructions: "Toggle 'Encrypt at Rest' to encrypt the key and certificate when it's stored in the db. This uses the Craft security key."|t('keychain'),
                 on: keypair.id ? keypair.isEncrypted : true,
                 errors: keypair.getErrors('isEncrypted')
             }) }}
         </div>
         <hr>
         {% if keypair.id %}
-            <div class="meta read-only">
+            <dl class="meta read-only">
                 <div class="data">
-                    <h5 class="heading">{{ "Created at"|t('app') }}</h5>
-                    <div class="value">{{ keypair.dateCreated|datetime('short') }}</div>
+                    <dt class="heading">{{ "Created at"|t('app') }}</dt>
+                    <dd class="value">{{ keypair.dateCreated|datetime('short') }}</dd>
                 </div>
                 <div class="data">
-                    <h5 class="heading">{{ "Updated at"|t('app') }}</h5>
-                    <div class="value">{{ keypair.dateUpdated|datetime('short') }}</div>
+                    <dt class="heading">{{ "Updated at"|t('app') }}</dt>
+                    <dd class="value">{{ keypair.dateUpdated|datetime('short') }}</dd>
                 </div>
-            </div>
+                <div class="data">
+                    <dt class="heading">{{ "Certificate expires at" }}</dt>
+                    <dd class="value">{{ keypair.certificateExpiration|datetime('short') }}</dd>
+                </div>
+            </dl>
         {% endif %}
     </div>
 {% endblock %}
@@ -103,7 +84,5 @@
         required: true,
         rows: 10
     }) }}
-
-    <div class="item" data-position="right" data-colspan="1"></div>
 
 {% endblock %}

--- a/src/templates/_cp/edit/index.twig
+++ b/src/templates/_cp/edit/index.twig
@@ -63,7 +63,6 @@
 
     {{ forms.textareaField({
         label: "Key"|t('keychain'),
-        instructions: "Key"|t('keychain'),
         class: "code",
         id: 'key',
         name: 'key',
@@ -73,9 +72,16 @@
         rows: 10
     }) }}
 
+    {% if keypair.id %}
+    {% set headingSuffix %}
+    <div class="flex-grow"></div>
+    <a download class="btn" href="{{ cpUrl(baseCpPath ~ '/download-certificate', {keyId: keypair.id}) }}" data-icon="download">Download</a>
+    {% endset %}
+    {% endif %}
+
     {{ forms.textareaField({
         label: "Certificate"|t('keychain'),
-        instructions: "Certificate"|t('keychain'),
+        headingSuffix: headingSuffix ?? null,
         class: "code",
         id:   'certificate',
         name: 'certificate',

--- a/src/templates/_cp/edit/openssl.twig
+++ b/src/templates/_cp/edit/openssl.twig
@@ -13,57 +13,44 @@
                 on: keypair.id ? keypair.enabled : true,
                 errors: keypair.getErrors('enabled')
             }) }}
-            <hr>
-            <p>
-                {{ "Toggle 'Is Encrypted' to encrypt the key and certificate when it's stored in the db. This uses the Craft security key."|t('keychain') }}
-            </p>
             {{ forms.lightswitchField({
                 label: "Is Encrypted"|t('keychain'),
+                instructions: "Toggle 'Is Encrypted' to encrypt the key and certificate when it's stored in the db. This uses the Craft security key."|t('keychain'),
                 id: 'isEncrypted',
                 name: 'isEncrypted',
                 on: keypair.id ? keypair.isEncrypted : true,
                 errors: keypair.getErrors('isEncrypted')
             }) }}
         </div>
-        <hr>
-        {% if keypair.id %}
-            <div class="meta read-only">
-                <div class="data">
-                    <h5 class="heading">{{ "Created at"|t('app') }}</h5>
-                    <div class="value">{{ keypair.dateCreated|datetime('short') }}</div>
-                </div>
-                <div class="data">
-                    <h5 class="heading">{{ "Updated at"|t('app') }}</h5>
-                    <div class="value">{{ keypair.dateUpdated|datetime('short') }}</div>
-                </div>
-            </div>
-        {% endif %}
     </div>
 {% endblock %}
 
 {% block content %}
 
-    <div class="grid first" data-max-cols="3">
-        <div class="item" data-position="left" data-colspan="2">
+    <div class="flex-fields">
+        <input type="hidden" name="action" value="{{ baseActionPath }}/upsert/openssl">
+        <input type="hidden" name="plugin" value="{{ pluginHandle }}">
 
-            <input type="hidden" name="action"
-                   value="{{ baseActionPath }}/upsert/openssl">
-            <input type="hidden" name="plugin" value="{{ pluginHandle }}"/>
-            {{ redirectInput(baseCpPath) }}
+        {{ redirectInput(baseCpPath) }}
 
-            {% if keypair.id %}<input type="hidden" name="identifier" value="{{ keypair.id }}">{% endif %}
+        {{ forms.textField({
+            label: 'Days Expiry',
+            id: 'daysExpiry',
+            name: 'daysExpiry',
+            type: 'number',
+            placeholder: 365,
+            fieldClass: 'width-75',
+        }) }}
 
-            {% for key, value in options.attributes %}
-                {{ forms.textField({
-                    label: options.labels[key],
-                    id: key,
-                    name: key,
-                    placeholder: value['default']
-                }) }}
-            {% endfor %}
-
-        </div>
-        <div class="item" data-position="right" data-colspan="1"></div>
+        {% for key, value in options.attributes %}
+            {{ forms.textField({
+                label: options.labels[key],
+                id: key,
+                name: key,
+                placeholder: value['default'],
+                fieldClass: 'width-75'
+            }) }}
+        {% endfor %}
     </div>
 
 {% endblock %}

--- a/src/templates/_cp/index.twig
+++ b/src/templates/_cp/index.twig
@@ -5,7 +5,7 @@
     <div class="btngroup">
         <a class="btn submit add icon"
            href="{{ cpUrl(baseCpPath ~ '/new') }}">{{ 'Add New Key Pair'|t('keychain') }}</a>
-        <div class="btn submit menubtn"></div>
+        <button type="button" class="btn submit menubtn" aria-label="{{ 'More actions'|t('app') }}"></button>
         <div class="menu">
             <ul>
                 <li><a class="formsubmit"
@@ -18,13 +18,14 @@
 
 {% block content %}
     <div class="elements">
-        <div class="tableview">
+        <div class="tableview tablepane">
             <table class="data fullwidth">
                 <thead>
                 <tr>
-                    <td scope="col" data-attribute="description">Description</td>
-                    <td scope="col" data-attribute="dateCreated">Date Created</td>
-                    <td scope="col" data-attribute="dateUpdated">Date Updated</td>
+                    <th scope="col" data-attribute="description">Description</th>
+                    <th scope="col" data-attribute="dateCreated">Date Created</th>
+                    <th scope="col" data-attribute="dateUpdated">Date Updated</th>
+                    <th scope="col" data-attribute="dateExpires">Date Certificate Expires</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -37,13 +38,14 @@
                                 <span class="status {% if keypair.enabled %}active{% else %}inactive{% endif %}"></span>
                                 <div class="label">
                                     <span class="title">
-                                        <a href="{{ cpUrl(baseCpPath ~'/' ~ keypair.id) }}">{{ keypair.description }}</a>
+                                        <a href="{{ cpUrl(baseCpPath ~'/' ~ keypair.id) }}">{{ keypair.description|default('(Untitled)') }}</a>
                                     </span>
                                 </div>
                             </div>
                         </td>
                         <td data-title="Date Created">{{ keypair.dateCreated|date }}</td>
                         <td data-title="Date Updated">{{ keypair.dateUpdated|date }}</td>
+                        <td data-title="Date Certificate Expires">{{ keypair.certificateExpiration|date }}</td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/src/web/assets/js/GenerateKeyPair.js
+++ b/src/web/assets/js/GenerateKeyPair.js
@@ -31,18 +31,20 @@
                 {
                     plugin: this.$plugin
                 },
-                $.proxy(function (response, textStatus) {
+                function (response, textStatus) {
                     this.$spinner.addClass('hidden');
 
                     if (textStatus === 'success') {
-                        Craft.cp.displayNotice('Key pair created!');
+                        Craft.cp.displaySuccess(response.message || 'Key pair created!');
                         //update select
                         this.$selectInput.find('options').prop('selected', false);
                         this.$selectInput.append(
                             $('<option value="' + response.id + '" selected>' + response.description + '</option>')
                         )
+                    } else {
+                        Craft.cp.displayError(response.message);
                     }
-                }, this)
+                }.bind(this)
             );
         }
     })


### PR DESCRIPTION
The OpenSSL create form would fail for invalid or empty inputs. The form also lacked the ability to specify the certificate expiry days. The errors are now displayed via Craft failure flash or success.

Expose the keypair certificate expiration date.